### PR TITLE
Erb whedon

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,22 +1,23 @@
-openjournals/joss-reviews:
-  editor_team_id: 2009411
-  papers: openjournals/joss-papers
-  reviewers: https://bit.ly/joss-reviewers
-  site_host: http://joss.theoj.org
-  site_api_key: <%= ENV['JOSS_API_KEY'] %>
+journals:
+  - openjournals/joss-reviews:
+      editor_team_id: 2009411
+      papers: openjournals/joss-papers
+      reviewers: https://bit.ly/joss-reviewers
+      site_host: http://joss.theoj.org
+      site_api_key: <%= ENV['JOSS_API_KEY'] %>
 
-openjournals/jose-reviews:
-  editor_team_id: 2414911
-  papers: openjournals/jose-papers
-  # TODO: Create this spreadsheet or equivalent
-  reviewers: https://bit.ly/joss-reviewers
-  # TODO: Wherever this is deployed
-  site_host: http://joss.theoj.org
-  site_api_key: <%= ENV['JOSE_API_KEY'] %>
+  - openjournals/jose-reviews:
+      editor_team_id: 2414911
+      papers: openjournals/jose-papers
+      # TODO: Create this spreadsheet or equivalent
+      reviewers: https://bit.ly/joss-reviewers
+      # TODO: Wherever this is deployed
+      site_host: http://joss.theoj.org
+      site_api_key: <%= ENV['JOSE_API_KEY'] %>
 
-openjournals/joss-reviews-testing:
-  editor_team_id: 2009411
-  papers: openjournals/joss-papers-testing
-  reviewers: "https://github.com/search?q=reviewers"
-  site_host: http://joss.theoj.org
-  site_api_key: <%= ENV['JOSS_API_KEY_TESTING'] %>
+  - openjournals/joss-reviews-testing:
+      editor_team_id: 2009411
+      papers: openjournals/joss-papers-testing
+      reviewers: "https://github.com/search?q=reviewers"
+      site_host: http://joss.theoj.org
+      site_api_key: <%= ENV['JOSS_API_KEY_TESTING'] %>

--- a/whedon.rb
+++ b/whedon.rb
@@ -14,10 +14,12 @@ config_file 'config/settings.yml'
 set :configs, {}
 
 # 'settings.journals' comes from sinatra/config_file
-settings.journals.each do |nwo, config|
-  team_id = config["editor_team_id"]
-  config["editors"] = settings.github.team_members(team_id).collect { |e| e.login }.sort
-  settings.configs[nwo] = OpenStruct.new config
+settings.journals.each do |journal|
+  journal.each do |nwo, params|
+    team_id = params["editor_team_id"]
+    params["editors"] = settings.github.team_members(team_id).collect { |e| e.login }.sort
+    settings.configs[nwo] = OpenStruct.new params
+  end
 end
 
 # Before we handle the request we extract the issue body to grab the whedon

--- a/whedon.rb
+++ b/whedon.rb
@@ -3,14 +3,18 @@ require 'json'
 require 'octokit'
 require 'rest-client'
 require 'sinatra'
+require 'sinatra/config_file'
 
 set :views, Proc.new { File.join(root, "responses") }
 set :gh_token, ENV["GH_TOKEN"]
 set :github, Octokit::Client.new(:access_token => settings.gh_token)
 set :magic_word, "bananas"
 
+config_file 'config/settings.yml'
 set :configs, {}
-YAML.load_file("config/settings.yml").each do |nwo, config|
+
+# 'settings.journals' comes from sinatra/config_file
+settings.journals.each do |nwo, config|
   team_id = config["editor_team_id"]
   config["editors"] = settings.github.team_members(team_id).collect { |e| e.login }.sort
   settings.configs[nwo] = OpenStruct.new config
@@ -192,7 +196,7 @@ def start_review
   reviewer = issue.body.match(/\*\*Reviewer:\*\*\s*.@(\S*)/)[1]
   # Check we have an editor and a reviewer
   raise unless (editor && reviewer)
-  url = "#{@config.site_host}/papers/api_start_review?id=#{@issue_id}&editor=#{editor}&reviewer=#{reviewer}&secret=#{ENV['JOSS_API_KEY']}"
+  url = "#{@config.site_host}/papers/api_start_review?id=#{@issue_id}&editor=#{editor}&reviewer=#{reviewer}&secret=#{@config.site_api_key}"
   # TODO let's do some error handling here please
   puts "POSTING TO #{url}"
   response = RestClient.post(url, "")


### PR DESCRIPTION
In order to use environment variables in Sinatra YAML configs, we need to load the settings using the `config_file` syntax rather than doing a `YAML.load`.

