### PR TITLE
Separate editor and non-editor 'commands' (closes #26)

### DIFF
--- a/responses/commands_public.erb
+++ b/responses/commands_public.erb
@@ -1,0 +1,18 @@
+Here are some things you can ask me to do:
+
+```
+# List all of Whedon's capabilities
+@whedon commands
+
+# List of editor GitHub usernames
+@whedon list editors
+
+# List of reviewers together with programming language preferences and domain expertise
+@whedon list reviewers
+
+ðŸš§ ðŸš§ ðŸš§ Experimental Whedon features ðŸš§ ðŸš§ ðŸš§
+
+# Compile the paper
+@whedon generate pdf
+
+```

--- a/responses/commands_public.erb
+++ b/responses/commands_public.erb
@@ -1,7 +1,7 @@
 Here are some things you can ask me to do:
 
 ```
-# List all of Whedon's capabilities
+# List Whedon's capabilities
 @whedon commands
 
 # List of editor GitHub usernames
@@ -10,7 +10,7 @@ Here are some things you can ask me to do:
 # List of reviewers together with programming language preferences and domain expertise
 @whedon list reviewers
 
-ðŸš§ ðŸš§ ðŸš§ Experimental Whedon features ðŸš§ ðŸš§ ðŸš§
+🚧 🚧 🚧 Experimental Whedon features 🚧 🚧 🚧
 
 # Compile the paper
 @whedon generate pdf

--- a/whedon.rb
+++ b/whedon.rb
@@ -121,7 +121,11 @@ def robawt_respond
   puts "MESSAGE: #{@message}"
   case @message
   when /\A@whedon commands/i
-    respond erb :commands
+    if @config.editors.include?(@sender)
+      respond erb :commands
+    else
+      respond erb :commands_public
+    end
   when /\A@whedon assign (.*) as reviewer/i
     check_editor
     assign_reviewer($1)


### PR DESCRIPTION
Per #26, this separates the `commands` list into a "public" list that is given to non-editors when they request `@whedon commands` and the existing full list that is given only to editors.