### PR TITLE
Link new DOI URLs to preferred resolver

### DIFF
--- a/whedon.rb
+++ b/whedon.rb
@@ -188,7 +188,7 @@ end
 def assign_archive(doi_string)
   doi = doi_string[/\b(10[.][0-9]{4,}(?:[.][0-9]+)*\/(?:(?!["&\'<>])\S)+)\b/]
   if doi
-    doi_with_url = "<a href=\"http://dx.doi.org/#{doi}\" target=\"_blank\">#{doi}</a>"
+    doi_with_url = "<a href=\"https://doi.org/#{doi}\" target=\"_blank\">#{doi}</a>"
     new_body = issue.body.gsub(/\*\*Archive:\*\*\s*(.*|Pending)/i, "**Archive:** #{doi_with_url}")
     github_client.update_issue(@nwo, @issue_id, issue.title, new_body)
     respond "OK. #{doi_with_url} is the archive."


### PR DESCRIPTION
The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). ;-)