### PR TITLE
Added reStructuredText badge code to goodbye message.

### DIFF
--- a/responses/goodbye.erb
+++ b/responses/goodbye.erb
@@ -12,6 +12,10 @@ HTML:
 <a style="border-width:0" href="https://doi.org/<%= doi_prefix %>/<%= doi_journal %>.<%= id %>">
   <img src="<%= site_host %>/papers/<%= doi_prefix %>/<%= doi_journal %>.<%= id %>/status.svg" alt="DOI badge" >
 </a>
+
+reStructuredText:
+.. image:: <%= site_host %>/papers/<%= doi_prefix %>/<%= doi_journal %>.<%= id %>/status.svg
+   :target: https://doi.org/<%= doi_prefix %>/<%= doi_journal %>.<%= id %>
 ```
 This is how it will look in your documentation:
 


### PR DESCRIPTION
JOSS publishes a fair number of Python packages which predominantly use reStructuredText for documentation and READMEs. It would be helpful to provide an easy copy-and-paste badge for them.