### PR TITLE
Emojified the article proof/pdf notification

### DIFF
--- a/whedon.rb
+++ b/whedon.rb
@@ -410,7 +410,7 @@ class PDFWorker
     puts "Uploading #{pdf_path}"
     pdf_url = create_git_pdf(pdf_path, issue_id, papers_repo, journal_alias)
 
-    pdf_response = "[--> Check article proof :page_facing_up: <--](#{pdf_url})"
+    pdf_response = "[ :point_right: Check article proof :page_facing_up: :point_left: ](#{pdf_url})"
 
     # Finally, respond in the review issue with the PDF URL
     bg_respond(nwo, issue_id, pdf_response)


### PR DESCRIPTION
The arrows currently look like html comment markup and since there is already a page up emoji, the point right and left feel more natural for a GitHub comment workflow. 👯 

