### PR TITLE
Updated NumFOCUS donation link

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -15,7 +15,7 @@ journals:
       journal_launch_date: '2016-05-05'
       journal_issn: '2475-9066'
       site_name: Journal of Open Source Software
-      donate_url: https://www.flipcause.com/secure/cause_pdetails/Mjk3Nzk=
+      donate_url: https://numfocus.salsalabs.org/donate-to-joss/index.html
       site_api_key: <%= ENV['JOSS_API_KEY'] %>
       crossref_username: <%= ENV['CROSSREF_USERNAME'] %>
       crossref_password: <%= ENV['CROSSREF_PASSWORD'] %>
@@ -34,7 +34,7 @@ journals:
       journal_launch_date: '2018-03-07'
       journal_issn: '2577-3569'
       site_name: Journal of Open Source Education
-      donate_url: https://www.flipcause.com/secure/cause_pdetails/Mjk3ODA=
+      donate_url: https://numfocus.salsalabs.org/donate-to-open-journals/index.html
       site_api_key: <%= ENV['JOSE_API_KEY'] %>
       crossref_username: <%= ENV['CROSSREF_USERNAME'] %>
       crossref_password: <%= ENV['CROSSREF_PASSWORD'] %>

--- a/config/settings-test.yml
+++ b/config/settings-test.yml
@@ -11,5 +11,5 @@ journals:
       journal_alias: joss
       journal_launch_date: '2016-05-05'
       site_name: Journal of Open Source Software
-      donate_url: https://www.flipcause.com/secure/cause_pdetails/Mjk3Nzk=
+      donate_url: https://numfocus.salsalabs.org/donate-to-joss/index.html
       site_api_key: <%= ENV['JOSS_API_KEY'] %>


### PR DESCRIPTION
Hi, I am a new staff member at NumFOCUS. We have updated our donation provider from Flipcause to Salsa. The new links are: 

https://numfocus.salsalabs.org/donate-to-open-journals/index.html

https://numfocus.salsalabs.org/donate-to-joss/index.html

https://numfocus.salsalabs.org/donate-to-jose/index.html

Please update your website accordingly. : )

Thanks, 

Lisa Martin
NumFOCUS