### PR TITLE
fix assign first reviewer wording

### DIFF
--- a/whedon_api.rb
+++ b/whedon_api.rb
@@ -130,7 +130,7 @@ class WhedonApi < Sinatra::Base
     when /\A@whedon assign (.*) as reviewer/i
       check_editor
       assign_reviewer($1)
-      respond "OK, the reviewer is #{$1}"
+      respond "OK, #{$1} is now a reviewer"
     when /\A@whedon add (.*) as reviewer/i
       check_editor
       add_reviewer($1)


### PR DESCRIPTION
"now the reviewer" implied only one was needed. This is more general.