### PR TITLE
Use proper year in paper's footer

### DIFF
--- a/spec/doi_checker_spec.rb
+++ b/spec/doi_checker_spec.rb
@@ -16,7 +16,7 @@ describe DOIWorker do
     it "should know how to check DOIs" do
       expect(subject.check_dois(bibtex)).to eq(
           {
-            :invalid =>["10.1038/INVALID is INVALID", "http://notadoi.org/bioinformatics/btp450 is INVALID"],
+            :invalid =>["10.1038/INVALID is INVALID", "http://notadoi.org/bioinformatics/btp450 is INVALID because of 'https://doi.org/' prefix"],
             :missing=>[],
             :ok=>["10.1038/nmeth.3252 is OK"]
             }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,18 +34,24 @@ RSpec.configure do |config|
 
     stub_request(:head, "https://doi.org/10.1038/nmeth.3252").
       with(
-       headers: {
-      'Accept'=>'*/*',
-      'User-Agent'=>'Faraday v0.15.4'
-       }).to_return(status: 301, body: "", headers: {})
+        headers: {
+          'Accept'=>'*/*',
+          'User-Agent'=>'Faraday v0.15.4'
+        }).to_return(status: 301, body: "", headers: {})
 
     stub_request(:head, "https://doi.org/10.1038/INVALID").
       with(
-       headers: {
-        'Accept'=>'*/*',
-        'User-Agent'=>'Faraday v0.15.4'
-       }).to_return(status: 404, body: "", headers: {})
+        headers: {
+          'Accept'=>'*/*',
+          'User-Agent'=>'Faraday v0.15.4'
+        }).to_return(status: 404, body: "", headers: {})
 
+    stub_request(:head, "https://doi.org/http://notadoi.org/bioinformatics/btp450").
+      with(
+        headers: {
+          'Accept'=>'*/*',
+          'User-Agent'=>'Faraday v0.15.4'
+        }).to_return(status: 400, body: "", headers: {})
   end
 
   config.include RSpecMixin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,14 +36,14 @@ RSpec.configure do |config|
       with(
        headers: {
       'Accept'=>'*/*',
-      'User-Agent'=>'Faraday v0.14.0'
+      'User-Agent'=>'Faraday v0.15.4'
        }).to_return(status: 301, body: "", headers: {})
 
     stub_request(:head, "https://doi.org/10.1038/INVALID").
       with(
        headers: {
         'Accept'=>'*/*',
-        'User-Agent'=>'Faraday v0.14.0'
+        'User-Agent'=>'Faraday v0.15.4'
        }).to_return(status: 404, body: "", headers: {})
 
   end

--- a/workers.rb
+++ b/workers.rb
@@ -12,7 +12,7 @@ class PaperPreviewWorker
   SidekiqStatus::Container.ttl = 600
 
   def perform(repository_address, journal, sha)
-    ENV["CURRENT_YEAR"] = '3030'
+    ENV["CURRENT_YEAR"] = Time.new.year.to_s
     ENV["CURRENT_VOLUME"] = '1'
     ENV["CURRENT_ISSUE"] = '1'
 


### PR DESCRIPTION
Right now the [latest](https://joss.theoj.org/papers/10.21105/joss.01500) [papers](https://joss.theoj.org/papers/10.21105/joss.01554) are showing a footer with the year 3030.

This PR changes the place where that value is set as env var, using the current year instead.
