### PR TITLE
Adding both links for PDF proofs

### DIFF
--- a/github.rb
+++ b/github.rb
@@ -140,7 +140,7 @@ module GitHub
                                                 File.open("#{file_path.strip}").read,
                                                 :branch => "#{journal_alias}.#{id}")
 
-    return gh_response.content.html_url
+    return gh_response.content.html_url, gh_response.content.download_url
   end
 
   # Use the GitHub Contents API (https://developer.github.com/v3/repos/contents/)

--- a/workers.rb
+++ b/workers.rb
@@ -445,9 +445,9 @@ class PDFWorker
     # If we've got this far then push a copy of the PDF to the papers repository
     create_or_update_git_branch(issue_id, config.papers_repo, config.journal_alias)
 
-    pdf_url = create_git_pdf(pdf_path, issue_id, config.papers_repo, config.journal_alias)
+    pdf_url, pdf_download_url = create_git_pdf(pdf_path, issue_id, config.papers_repo, config.journal_alias)
 
-    pdf_response = "[ :point_right: Check article proof :page_facing_up: :point_left: ](#{pdf_url})"
+    pdf_response = ":point_right::page_facing_up: [Download article proof](#{pdf_download_url}) :page_facing_up: [View article proof on GitHub](#{pdf_url}) :page_facing_up: :point_left:"
 
     # Finally, respond in the review issue with the PDF URL
     bg_respond(nwo, issue_id, pdf_response)
@@ -505,7 +505,7 @@ class DepositWorker
     # If we've got this far then push a copy of the PDF to the papers repository
     create_or_update_git_branch(issue_id, config.papers_repo, config.journal_alias)
 
-    pdf_url = create_git_pdf(pdf_path, issue_id, config.papers_repo, config.journal_alias)
+    pdf_url, pdf_download_url = create_git_pdf(pdf_path, issue_id, config.papers_repo, config.journal_alias)
 
     crossref_xml_path = pdf_path.gsub('.pdf', '.crossref.xml')
     crossref_url = create_git_xml(crossref_xml_path, issue_id, config.papers_repo, config.journal_alias)


### PR DESCRIPTION
This PR changes the response from `@whedon generate pdf` to return two links – one that will download the PDF locally to the user's machine, the second a preview on GitHub.

<img width="929" alt="Screen Shot 2020-09-11 at 09 32 24" src="https://user-images.githubusercontent.com/4483/92893604-bbc39580-f411-11ea-80b2-eba7c2e0b130.png">
