### PR TITLE
More reliable tmp directories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sinatra-contrib', '2.0.2'
 gem 'twitter'
 gem 'unicorn', '5.3.1'
 gem 'pry-byebug'
-gem 'whedon', :git => 'https://github.com/openjournals/whedon.git', :ref => 'bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e'
+gem 'whedon', :git => 'https://github.com/openjournals/whedon.git', :ref => 'd14a699185fbbdd0898820571684f3df279c79b7'
 
 group :test do
   gem 'rack-test'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'sinatra-contrib', '2.0.2'
 gem 'twitter'
 gem 'unicorn', '5.3.1'
 gem 'pry-byebug'
-gem 'whedon', :git => 'https://github.com/openjournals/whedon.git', :ref => '364ded0628421ee74b57f3afaf0ba8272263904d'
+gem 'whedon', :git => 'https://github.com/openjournals/whedon.git', :ref => 'bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e'
 
 group :test do
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/openjournals/whedon.git
-  revision: 364ded0628421ee74b57f3afaf0ba8272263904d
-  ref: 364ded0628421ee74b57f3afaf0ba8272263904d
+  revision: bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e
+  ref: bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e
   specs:
     whedon (0.1.0)
       bibtex-ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/openjournals/whedon.git
-  revision: bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e
-  ref: bf8f7ebe2fa7fc0ef56964dc2783483bf66dd18e
+  revision: d14a699185fbbdd0898820571684f3df279c79b7
+  ref: d14a699185fbbdd0898820571684f3df279c79b7
   specs:
     whedon (0.1.0)
       bibtex-ruby


### PR DESCRIPTION
This PR moves all of the Whedon workers to use unique directories when executing. The uniqueness is derived from the Sidekiq job identifier `jid` which is unique to the spawned background process.

cx https://github.com/openjournals/buffy/issues/7