### PR TITLE
Add acceptance labels after PR with the compiled paper is created

### DIFF
--- a/spec/whedon_api_spec.rb
+++ b/spec/whedon_api_spec.rb
@@ -271,7 +271,7 @@ describe WhedonApi do
       expect(DepositWorker).to receive(:perform_async).once
       allow(Octokit::Client).to receive(:new).once.and_return(github_client)
       expect(github_client).to receive(:add_comment).once.with(anything, anything, /Attempting dry run of processing paper acceptance/)
-      expect(github_client).to receive(:label_issue).never
+      expect(github_client).to receive(:add_labels_to_an_issue).never
       post '/dispatch', whedon_accept_with_doi, {'CONTENT_TYPE' => 'application/json'}
     end
 
@@ -285,6 +285,7 @@ describe WhedonApi do
       expect(DepositWorker).to receive(:perform_async).once
       allow(Octokit::Client).to receive(:new).once.and_return(github_client)
       expect(github_client).to receive(:add_comment).once.with(anything, anything, /Doing it live! Attempting automated processing of paper acceptance.../)
+      expect(github_client).to receive(:add_labels_to_an_issue).never
       post '/dispatch', whedon_accept_for_reals_with_doi, {'CONTENT_TYPE' => 'application/json'}
     end
 

--- a/whedon_api.rb
+++ b/whedon_api.rb
@@ -336,12 +336,10 @@ class WhedonApi < Sinatra::Base
       end
 
       if dry_run == true
-        label_issue(@nwo, @issue_id, ['recommend-accept'])
         respond "```\nAttempting dry run of processing paper acceptance...\n```"
         DOIWorker.perform_async(@nwo, @issue_id, serialized_config, custom_branch)
         DepositWorker.perform_async(@nwo, @issue_id, serialized_config, custom_branch, dry_run=true)
       else
-        label_issue(@nwo, @issue_id, ['accepted', 'published'])
         respond "```\nDoing it live! Attempting automated processing of paper acceptance...\n```"
         DepositWorker.perform_async(@nwo, @issue_id, serialized_config, custom_branch, dry_run=false)
       end

--- a/workers.rb
+++ b/workers.rb
@@ -544,6 +544,7 @@ class DepositWorker
 
     if dry_run == true
       pr_url = create_deposit_pr(issue_id, config.papers_repo, config.journal_alias, dry_run)
+      labels = ['recommend-accept']
 
       if custom_branch
         pr_response = ":wave: @#{config.eic_team_name}, this paper is ready to be accepted and published.\n\n Check final proof :point_right: #{pr_url}\n\nIf the paper PDF and Crossref deposit XML look good in #{pr_url}, then you can now move forward with accepting the submission by compiling again with the flag `deposit=true` e.g.\n ```\n@whedon accept deposit=true from branch #{custom_branch} \n```"
@@ -560,13 +561,15 @@ class DepositWorker
       doi = "https://doi.org/#{config.doi_prefix}/#{config.journal_alias}.#{id}"
 
       pr_response = "🚨🚨🚨 **THIS IS NOT A DRILL, YOU HAVE JUST ACCEPTED A PAPER INTO #{config.journal_alias.upcase}!** 🚨🚨🚨\n\n Here's what you must now do:\n\n0. Check final PDF and Crossref metadata that was deposited :point_right: #{pr_url}\n1. Wait a couple of minutes, then verify that the paper DOI resolves [#{doi}](#{doi})\n2. If everything looks good, then close this review issue.\n3. Party like you just published a paper! 🎉🌈🦄💃👻🤘\n\n Any issues? Notify your editorial technical team..."
+      labels = ['accepted', 'published']
 
       # Only Tweet if configured with keys
       if config.twitter_consumer_key
         whedon_tweet(crossref_xml_path, nwo, issue_id, config)
       end
     end
-    # Finally, respond in the review issue with the PDF URL
+    # Finally, add labels and respond in the review issue with the PDF URL
+    label_issue(@nwo, @issue_id, labels)
     bg_respond(nwo, issue_id, pr_response)
     # Clean-up
     FileUtils.rm_rf("#{jid}") if Dir.exist?("#{jid}")


### PR DESCRIPTION
This PR moves the acceptance-related labeling to the DepositWorker, so labels are only added if there are not errors compiling the PDF 

Fixes openjournals/joss#994