### PR TITLE
CI: Print Ruby version without Bundler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,5 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: |
-        bundle exec ruby -v
+        ruby -v
         bundle exec rspec


### PR DESCRIPTION
This minor change presents Ruby version without also starting Bundler.